### PR TITLE
Refactor context into composable modules

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -1,90 +1,12 @@
-
-// context.js
-
-import { updateLevelBar, createLevelBox } from '../ui/levelBarManager.js';
-import { sendKakao, isKakaoMessage, getRoomBackground, toggleKakaoDisplay, clearKakaoMessages, scrollToBottom } from '../kakao/kakaoMessageManager.js';
-import { renderChoiceButtons, attachChoiceListener } from '../dialogue/choiceHandler.js';
-import { showAnswerInput } from '../dialogue/answerHandler.js';
-import { changeBackgroundInstant, changeBackgroundSmoothly, clearBackground } from '../ui/backgroundManager.js';
-import { showDialogue } from '../dialogue/showDialogue.js';
-import { jumpToNextInterrupt } from './skipManager.js';
-import { showPopup, showNotification } from '../ui/popup/popupHandler.js';
-import { autoUpdateSkipButton } from '../ui/control/skipButtonController.js';
+import domRefs from './domRefs.js';
+import state from './state.js';
+import buildMethods from './contextMethods.js';
 
 const context = {
-  gameWrapper: null,
-  kakaoBox: null,
-  choiceContainer: null,
-  talkWrapper: null,
-  nameEl: null,
-  bubbleEl: null,
-  kakaoOverlay: null,
-  overlayImage: null,
-  skipBtn: null,
-  saveBtn: null,
-  answerUi: null,
-  answerInput: null,
-  submitAnswer: null,
-  hintPopup: null,
-  hintStep1: null,
-  hintStep2: null,
-  hintBtn: null,
-  hintConfirm: null,
-  msgBox: null,
-  savePopup: null,
-  // 상태 관련
-  indexRef: { value: 0 },
-  skipModeRef: { value: false },
-  preventAutoAdvance: { value: false },
-  isWaitingForAnswer: { value: false },
-  notificationActive: false,
-  suppressClick: false,
-  gameStarted: false,
-  overlayJustCleared: false,
-  saveLoaded: false,
-  isRestored: false,
-  hintSystemInitialized: false,
-
-  // currentDialogue → getter/setter로만 관리
-  get currentDialogue() {
-    return window.currentDialogue;
-  },
-  set currentDialogue(val) {
-    window.currentDialogue = val;
-  },
-
-  // 기능 함수
-  updateLevelBar,
-  createLevelBox,
-  sendKakao,
-  isKakaoMessage,
-  getRoomBackground,
-  toggleKakaoDisplay,
-  clearKakaoMessages,
-  scrollToBottom,
-  renderChoiceButtons,
-  attachChoiceListener,
-  showAnswerInput,
-  changeBackgroundInstant,
-  changeBackgroundSmoothly,
-  clearBackground,
-  showDialogue,
-  jumpToNextInterrupt,
-
-  // 유틸 함수
-  setNotificationActive: (val) => {
-  context.notificationActive = val;
-  autoUpdateSkipButton(context);
-},
-  updateSkipButton: (enabled) => {
-    const btn = context.skipBtn;
-    if (!btn) return;
-
-    btn.disabled = !enabled;
-    btn.classList.toggle('btn-enabled', enabled);
-    btn.classList.toggle('btn-disabled', !enabled);
-  },
-  showPopup: (msg, target = context.msgBox) => showPopup(target, msg),
+  ...domRefs,
+  ...state,
 };
+
+Object.assign(context, buildMethods(context));
 
 export default context;

--- a/modules/core/contextMethods.js
+++ b/modules/core/contextMethods.js
@@ -1,0 +1,53 @@
+import { updateLevelBar, createLevelBox } from '../ui/levelBarManager.js';
+import {
+  sendKakao,
+  isKakaoMessage,
+  getRoomBackground,
+  toggleKakaoDisplay,
+  clearKakaoMessages,
+  scrollToBottom,
+} from '../kakao/kakaoMessageManager.js';
+import { renderChoiceButtons, attachChoiceListener } from '../dialogue/choiceHandler.js';
+import { showAnswerInput } from '../dialogue/answerHandler.js';
+import {
+  changeBackgroundInstant,
+  changeBackgroundSmoothly,
+  clearBackground,
+} from '../ui/backgroundManager.js';
+import { showDialogue } from '../dialogue/showDialogue.js';
+import { jumpToNextInterrupt } from './skipManager.js';
+import { showPopup } from '../ui/popup/popupHandler.js';
+import { autoUpdateSkipButton } from '../ui/control/skipButtonController.js';
+
+export default function buildMethods(context) {
+  return {
+    updateLevelBar,
+    createLevelBox,
+    sendKakao,
+    isKakaoMessage,
+    getRoomBackground,
+    toggleKakaoDisplay,
+    clearKakaoMessages,
+    scrollToBottom,
+    renderChoiceButtons,
+    attachChoiceListener,
+    showAnswerInput,
+    changeBackgroundInstant,
+    changeBackgroundSmoothly,
+    clearBackground,
+    showDialogue,
+    jumpToNextInterrupt,
+    setNotificationActive: (val) => {
+      context.notificationActive = val;
+      autoUpdateSkipButton(context);
+    },
+    updateSkipButton: (enabled) => {
+      const btn = context.skipBtn;
+      if (!btn) return;
+      btn.disabled = !enabled;
+      btn.classList.toggle('btn-enabled', enabled);
+      btn.classList.toggle('btn-disabled', !enabled);
+    },
+    showPopup: (msg, target = context.msgBox) => showPopup(target, msg),
+  };
+}

--- a/modules/core/domRefs.js
+++ b/modules/core/domRefs.js
@@ -1,0 +1,24 @@
+const domRefs = {
+  gameWrapper: null,
+  kakaoBox: null,
+  choiceContainer: null,
+  talkWrapper: null,
+  nameEl: null,
+  bubbleEl: null,
+  kakaoOverlay: null,
+  overlayImage: null,
+  skipBtn: null,
+  saveBtn: null,
+  answerUi: null,
+  answerInput: null,
+  submitAnswer: null,
+  hintPopup: null,
+  hintStep1: null,
+  hintStep2: null,
+  hintBtn: null,
+  hintConfirm: null,
+  msgBox: null,
+  savePopup: null,
+};
+
+export default domRefs;

--- a/modules/core/state.js
+++ b/modules/core/state.js
@@ -1,0 +1,24 @@
+let _currentDialogue = [];
+
+const state = {
+  indexRef: { value: 0 },
+  skipModeRef: { value: false },
+  preventAutoAdvance: { value: false },
+  isWaitingForAnswer: { value: false },
+  notificationActive: false,
+  suppressClick: false,
+  gameStarted: false,
+  overlayJustCleared: false,
+  saveLoaded: false,
+  isRestored: false,
+  hintSystemInitialized: false,
+
+  get currentDialogue() {
+    return _currentDialogue;
+  },
+  set currentDialogue(val) {
+    _currentDialogue = val;
+  },
+};
+
+export default state;

--- a/modules/dialogue/choiceHandler.js
+++ b/modules/dialogue/choiceHandler.js
@@ -44,7 +44,7 @@ export function attachChoiceListener(container, context, showDialogue) {
       ...branch,
       ...rest
     ];
-    window.currentDialogue = updated;
+    context.currentDialogue = updated;
     context.indexRef.value++;
 
     let idx = context.indexRef.value;


### PR DESCRIPTION
## Summary
- extract DOM references into `domRefs.js`
- move state data into `state.js`
- gather utility functions in `contextMethods.js`
- build context object from these parts

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a6cfe7a4832b972639e38638f009