### PR TITLE
Refactor dialogue state storage

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -44,13 +44,14 @@ const context = {
   saveLoaded: false,
   isRestored: false,
   hintSystemInitialized: false,
+  _currentDialogue: null,
 
   // currentDialogue → getter/setter로만 관리
   get currentDialogue() {
-    return window.currentDialogue;
+    return this._currentDialogue;
   },
   set currentDialogue(val) {
-    window.currentDialogue = val;
+    this._currentDialogue = val;
   },
 
   // 기능 함수

--- a/modules/dialogue/choiceHandler.js
+++ b/modules/dialogue/choiceHandler.js
@@ -44,7 +44,7 @@ export function attachChoiceListener(container, context, showDialogue) {
       ...branch,
       ...rest
     ];
-    window.currentDialogue = updated;
+    context.currentDialogue = updated;
     context.indexRef.value++;
 
     let idx = context.indexRef.value;


### PR DESCRIPTION
## Summary
- keep current dialogue inside the context object
- update choice handler to use context instead of the `window` object

## Testing
- `node -e "import('./modules/core/context.js').then(m=>{const c=m.default; console.log('currentDialogue', c.currentDialogue); c.currentDialogue=['a']; console.log(c._currentDialogue); console.log(c.currentDialogue);});"`

------
https://chatgpt.com/codex/tasks/task_e_6846928dcc44832bbc07407ecbf79f81